### PR TITLE
重寫播放器事件和變數名稱

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -118,7 +118,8 @@ const scrollToTop = () => {
 watch(
   () => currentPath.value,
   () => {
-    if (mobileMenuRef.value?.classList.contains('is-visible')) mobileMenuRef.value?.classList.remove('is-visible')
+    if (mobileMenuRef.value?.classList.contains('is-visible'))
+      mobileMenuRef.value?.classList.remove('is-visible')
     scrollToTop()
     isPlayable.value = currentPath.value.split('/').length > 2
 
@@ -127,7 +128,8 @@ watch(
 )
 
 const onDrawerBackgroundClick = (event) => {
-  if (event.target.classList.contains('ts-app-drawer')) mobileMenuRef.value?.classList.remove('is-visible')
+  if (event.target.classList.contains('ts-app-drawer'))
+    mobileMenuRef.value?.classList.remove('is-visible')
 }
 
 // 相容舊的
@@ -143,10 +145,7 @@ if (currentPath.value?.startsWith('#record')) {
 
 <template>
   <ErrorBlankSlate v-if="isError" style="height: 100vh; width: 100vw" />
-  <AgeRestrictPage
-    v-else-if="!isAdult"
-    @age-restrict="ageRestrict"
-  />
+  <AgeRestrictPage v-else-if="!isAdult" @age-restrict="ageRestrict" />
   <div v-else class="cell ts-app-layout is-horizontal is-full">
     <!-- StreamerList for desktop user -->
     <div id="sidebar" class="tablet-:has-hidden cell is-scrollable">

--- a/src/components/AgeRestrictPage.vue
+++ b/src/components/AgeRestrictPage.vue
@@ -30,9 +30,7 @@ defineEmits(['ageRestrict'])
       >
         進入 Enter
       </button>
-      <button class="ts-button is-fluid is-disabled" disabled>
-        離開 Leave
-      </button>
+      <button class="ts-button is-fluid is-disabled" disabled>離開 Leave</button>
     </div>
   </div>
 </template>

--- a/src/components/centerBlock/OverlayPlayer.vue
+++ b/src/components/centerBlock/OverlayPlayer.vue
@@ -25,19 +25,122 @@ const props = defineProps({
 })
 defineEmits(['change-quality'])
 
+// Handle touch mode
 const touchMode = ref(false)
 const isTouch = (event) => event?.pointerType === 'touch'
 
-const overlayVideo = ref(null)
-const video = ref(null)
+// Handle video element
+const videoRef = ref(null)
+
+const overlayVideoRef = ref(null)
+
+const isVideoError = ref(false)
+
+const isBuffering = ref(false)
+
+const isPaused = ref(true)
+
+const isFullscreen = ref(false)
+
+const currentTime = ref(0)
+
+const timeText = computed(() => timeToText(currentTime.value))
+
+const draggingCurrentTime = ref(undefined)
+
+const duration = ref(0)
+
+const durationText = computed(() => timeToText(duration.value))
+
+const playbackRate = ref(1)
+
+const updatePlayerStatus = () => {
+  isBuffering.value = false
+  currentTime.value = draggingCurrentTime.value ?? videoRef.value?.currentTime
+  duration.value = videoRef.value?.duration
+  isPaused.value = videoRef.value?.paused
+  isMuted.value = videoRef.value?.muted
+  volume.value = videoRef.value?.muted ? 0 : reverseVolume(videoAmplifier.value?.getAmpLevel() * 100)
+  isFullscreen.value = document.fullscreenElement !== null
+  playbackRate.value = videoRef.value?.playbackRate
+}
+
+const handlePlayerLoaded = () => {
+  updatePlayerStatus()
+  showUIAndResetAutoHideTimer()
+}
+
+const playbackRateList = ref([
+  { value: 0.25, text: '0.25x' },
+  { value: 0.5, text: '0.5x' },
+  { value: 1, text: '1x' },
+  { value: 1.5, text: '1.5x' },
+  { value: 2, text: '2x' },
+  { value: 3, text: '3x' },
+  { value: 5, text: '5x' }
+])
+
+const setPlaybackRate = (rate) => {
+  videoRef.value.playbackRate = rate
+  updatePlayerStatus()
+}
+
+const debounceSeekDrag = () => {
+  draggingCurrentTime.value = currentTime.value
+  debounce(setTime, 500)()
+}
+
+const setTime = () => {
+  draggingCurrentTime.value = undefined
+  videoRef.value.currentTime = currentTime.value
+  updatePlayerStatus()
+}
+
+const seekForward = () => {
+  currentTime.value = Math.min(currentTime.value + 5, duration.value)
+  setTime()
+}
+
+const seekBackward = () => {
+  currentTime.value = Math.max(currentTime.value - 5, 0)
+  setTime()
+}
+
+const togglePlay = () => {
+  if (!props.resource) return
+  if (videoRef.value.paused) {
+    videoRef.value.play()
+  } else {
+    videoRef.value.pause()
+  }
+  updatePlayerStatus()
+}
+
+const toggleFullscreen = () => {
+  if (!props.resource) return
+  if (!document.fullscreenElement) {
+    overlayVideoRef.value?.requestFullscreen().catch((err) => {
+      console.error(`Error attempting to enable fullscreen mode: ${err.message} (${err.name})`)
+    })
+  } else {
+    document.exitFullscreen()
+  }
+}
+
+const setBufferAndErrorState = (buffering, error) => {
+  isBuffering.value = buffering
+  isVideoError.value = error
+}
+
+// Handle video volume
 const videoAmplifier = computed(() => {
-  if (!video.value) return null
+  if (!videoRef.value) return null
   const context = new (window.AudioContext || window.webkitAudioContext)(),
     result = {
       context: context,
-      source: context.createMediaElementSource(video.value),
+      source: context.createMediaElementSource(videoRef.value),
       gain: context.createGain(),
-      media: video.value,
+      media: videoRef.value,
       amplify: function (multiplier) {
         result.gain.gain.value = multiplier
       },
@@ -51,6 +154,10 @@ const videoAmplifier = computed(() => {
   return result
 })
 
+const isMuted = ref(false)
+
+const volume = ref(100)
+
 const convertVolume = (volume) => {
   if (volume <= 100) return volume
   return 100 + (volume - 100) * 2
@@ -61,149 +168,16 @@ const reverseVolume = (volume) => {
   return 100 + (volume - 100) / 2
 }
 
-const isVideoError = ref(false)
-
-const rateDropdown = ref(null)
-const qualityDropdown = ref(null)
-const isDropdownVisible = () =>
-  rateDropdown.value?.classList.contains('is-visible') ||
-  qualityDropdown.value?.classList.contains('is-visible')
-
-const isBuffering = ref(false)
-
-// Handle show / (auto) hide UI
-const autoHideTimer = ref(null)
-const isPlayerHidden = () => overlayVideo.value?.classList.contains('auto-hidden') ?? false
-
-const resetAutoHideTimer = () => {
-  if (autoHideTimer.value) {
-    clearTimeout(autoHideTimer.value)
-    autoHideTimer.value = null
-  }
-}
-
-const hideUI = () => {
-  // Skip if dropdown is visible
-  if (isDropdownVisible()) return
-
-  resetAutoHideTimer()
-
-  overlayVideo.value?.classList.add('auto-hidden')
-}
-
-const showUIAndResetAutoHideTimer = (isTouchEvent) => {
-  resetAutoHideTimer()
-
-  // set timeout to wait of idle time
-  const t = setTimeout(hideUI, (isTouchEvent ? 2 : 1) * 1000)
-  autoHideTimer.value = t
-
-  overlayVideo.value?.classList.remove('auto-hidden')
-}
-
-const handlePlayerPointerMove = (event) => {
-  const isTouchEvent = isTouch(event)
-
-  // Set touch mode
-  touchMode.value = isTouchEvent
-
-  showUIAndResetAutoHideTimer(isTouchEvent)
-}
-
-const timeToText = (time) => {
-  const hours = Math.floor(time / 3600)
-  const minutes = Math.floor((time % 3600) / 60)
-  const seconds = Math.floor(time % 60)
-
-  const hourValue = hours.toString().padStart(2, '0')
-  const minuteValue = minutes.toString().padStart(2, '0')
-  const secondValue = seconds.toString().padStart(2, '0')
-
-  return `${hourValue}:${minuteValue}:${secondValue}`
-}
-
-const isPaused = ref(true)
-
-const isMuted = ref(false)
-
-const volume = ref(100)
-
-const currentTime = ref(0)
-
-const draggingCurrentTime = ref(undefined)
-
-const duration = ref(0)
-
-const isFullscreen = ref(false)
-
-const timeText = computed(() => timeToText(currentTime.value))
-
-const durationText = computed(() => timeToText(duration.value))
-
-const rate = ref(1)
-
-const rateList = ref([
-  { value: 0.25, text: '0.25x' },
-  { value: 0.5, text: '0.5x' },
-  { value: 1, text: '1x' },
-  { value: 1.5, text: '1.5x' },
-  { value: 2, text: '2x' },
-  { value: 3, text: '3x' },
-  { value: 5, text: '5x' }
-])
-
-const updateStatus = () => {
-  isBuffering.value = false
-  currentTime.value = draggingCurrentTime.value ?? video.value?.currentTime
-  duration.value = video.value?.duration
-  isPaused.value = video.value?.paused
-  isMuted.value = video.value?.muted
-  volume.value = video.value?.muted ? 0 : reverseVolume(videoAmplifier.value?.getAmpLevel() * 100)
-  isFullscreen.value = document.fullscreenElement !== null
-  rate.value = video.value?.playbackRate
-}
-
-const onPlayerReady = () => {
-  updateStatus()
-  handlePlayerPointerMove()
-}
-
-const setRate = (rate) => {
-  video.value.playbackRate = rate
-  updateStatus()
-}
-
-const onSeekDrag = () => {
-  draggingCurrentTime.value = currentTime.value
-  debounce(setTime, 500)()
-}
-
-const setTime = () => {
-  draggingCurrentTime.value = undefined
-  video.value.currentTime = currentTime.value
-  updateStatus()
-}
-
-const seekForward = () => {
-  currentTime.value = Math.min(currentTime.value + 5, duration.value)
-  setTime()
-}
-
-const seekBackward = () => {
-  currentTime.value = Math.max(currentTime.value - 5, 0)
-  setTime()
-}
-
 const setVolume = () => {
   if (volume.value === 0) {
-    video.value.muted = true
-    updateStatus()
+    videoRef.value.muted = true
+    updatePlayerStatus()
     return
   }
 
-  video.value.muted = false
+  videoRef.value.muted = false
   videoAmplifier.value?.amplify(convertVolume(volume.value) / 100)
-  updateStatus()
+  updatePlayerStatus()
 }
 
 const volumeUp = () => {
@@ -222,103 +196,77 @@ const resetVolume = () => {
 }
 
 const toggleMute = () => {
-  video.value.muted = !video.value.muted
-  updateStatus()
+  videoRef.value.muted = !videoRef.value.muted
+  updatePlayerStatus()
 }
 
-const onMuteButtonPointerUp = (event) => {
-  setTimeout(() => handlePlayerPointerMove(event), 50)
-  toggleMute()
-}
+// Handle dropdown
+const rateDropdownRef = ref(null)
+const qualityDropdownRef = ref(null)
+const isDropdownVisible = () =>
+  rateDropdownRef.value?.classList.contains('is-visible') ||
+  qualityDropdownRef.value?.classList.contains('is-visible')
 
-const togglePlay = () => {
-  if (!props.resource) return
-  if (video.value.paused) {
-    video.value.play()
-  } else {
-    video.value.pause()
-  }
-  updateStatus()
-}
+// Handle show / (auto) hide UI
+const autoHideTimer = ref(null)
+const isPlayerHidden = () => overlayVideoRef.value?.classList.contains('auto-hidden') ?? false
 
-const onOverlayPointerUp = (event) => {
-  setTimeout(() => handlePlayerPointerMove(event), 50)
-}
-
-const onPlayButtonPointerUp = (event) => {
-  const isHidden = isPlayerHidden()
-  setTimeout(() => handlePlayerPointerMove(event), 50)
-  if (isHidden) {
-    return
-  }
-  setTimeout(() => handlePlayerPointerMove(event), 50)
-  togglePlay()
-}
-
-const toggleFullscreen = () => {
-  if (!props.resource) return
-  if (!document.fullscreenElement) {
-    overlayVideo.value?.requestFullscreen().catch((err) => {
-      console.error(`Error attempting to enable fullscreen mode: ${err.message} (${err.name})`)
-    })
-  } else {
-    document.exitFullscreen()
+const resetAutoHideTimer = () => {
+  if (autoHideTimer.value) {
+    clearTimeout(autoHideTimer.value)
+    autoHideTimer.value = null
   }
 }
 
-const onFullscreenButtonPointerUp = (event) => {
-  setTimeout(() => handlePlayerPointerMove(event), 50)
-  toggleFullscreen()
+const hideUI = () => {
+  // Skip if dropdown is visible
+  if (isDropdownVisible()) return
+
+  resetAutoHideTimer()
+
+  overlayVideoRef.value?.classList.add('auto-hidden')
 }
 
-const onKeyDown = (event) => {
-  if (
-    document.activeElement instanceof HTMLInputElement &&
-    !document.activeElement.classList.contains('player-slider')
-  )
-    return
-  if (!video.value) return
-  if (!props.resource) return
+const showUIAndResetAutoHideTimer = (isTouchEvent = false) => {
+  resetAutoHideTimer()
 
-  handlePlayerPointerMove(event)
+  // set timeout to wait of idle time
+  const t = setTimeout(hideUI, (isTouchEvent ? 2 : 1) * 1000)
+  autoHideTimer.value = t
 
-  switch (event.key) {
-    // Play-Pause
-    case ' ':
-      event.preventDefault()
-      togglePlay()
-      break
-    // Seek
-    case 'ArrowRight':
-      event.preventDefault()
-      seekForward()
-      break
-    case 'ArrowLeft':
-      event.preventDefault()
-      seekBackward()
-      break
-    // Volume
-    case 'ArrowUp':
-      event.preventDefault()
-      volumeUp()
-      break
-    case 'ArrowDown':
-      event.preventDefault()
-      volumeDown()
-      break
-    case 'M':
-    case 'm':
-      event.preventDefault()
-      toggleMute()
-      break
-  }
+  overlayVideoRef.value?.classList.remove('auto-hidden')
 }
 
-const onVolumeMouseWheel = (event) => {
+const handlePlayerPointerEvent = (event) => {
+  const isTouchEvent = isTouch(event)
+
+  // Set touch mode
+  touchMode.value = isTouchEvent
+
+  showUIAndResetAutoHideTimer(isTouchEvent)
+}
+
+// Utils
+const timeToText = (time) => {
+  const hours = Math.floor(time / 3600)
+  const minutes = Math.floor((time % 3600) / 60)
+  const seconds = Math.floor(time % 60)
+
+  const hourValue = hours.toString().padStart(2, '0')
+  const minuteValue = minutes.toString().padStart(2, '0')
+  const secondValue = seconds.toString().padStart(2, '0')
+
+  return `${hourValue}:${minuteValue}:${secondValue}`
+}
+
+// Do something with pointer event trigger
+const withHandlePointerEvent = (event, callback) => {
+  // Only work on main hand and left click
+  if (!event.isPrimary || event.button !== 0) return
+
   event.preventDefault()
-  if (event.deltaY > 0) volumeDown()
-  else volumeUp()
-  handlePlayerPointerMove(event)
+  handlePlayerPointerEvent(event)
+  callback(event)
 }
 
 // Handle player click
@@ -386,17 +334,20 @@ const handlePlayerFirstClick = (event, isHidden, isTouchEvent) => {
 
 const handlePlayerSecondClick = (event, isTouchEvent) => {
   // Skip if video is not ready or dropdown is visible
-  if (!video.value || isDropdownVisible()) {
+  if (!videoRef.value || isDropdownVisible()) {
     return
   }
 
   if (isTouchEvent && !isFirstClickUIHidden.value) {
     // Trigger show UI to reset auto hide timer
     showUIAndResetAutoHideTimer(isTouchEvent)
-    // Click center will toggle play, left and right sides will seek time
+
+    // Get click position
     const elementOffsetX = event.target.getBoundingClientRect().x
     const eventX = event.clientX - elementOffsetX
-    const leftSideEnd = video.value.clientWidth / 3
+
+    // Click center will toggle play, left and right sides will seek time
+    const leftSideEnd = videoRef.value.clientWidth / 3
     const RightSideStart = leftSideEnd * 2
     if (eventX < leftSideEnd) {
       seekBackward()
@@ -417,45 +368,89 @@ const handlePlayerSecondClick = (event, isTouchEvent) => {
   }
 }
 
-const onVideoPlaying = () => {
-  isBuffering.value = false
-  isVideoError.value = false
+// Handle key event
+const handleKeyDown = (event) => {
+  // Skip if input is focused or video is not ready
+  const shouldSkip =
+    document.activeElement instanceof HTMLInputElement &&
+    !document.activeElement.classList.contains('player-slider')
+  if (shouldSkip || !videoRef.value || !props.resource) {
+    return
+  }
+
+  showUIAndResetAutoHideTimer()
+
+  switch (event.key) {
+    // Play-Pause
+    case ' ':
+      event.preventDefault()
+      togglePlay()
+      break
+    // Seek
+    case 'ArrowRight':
+      event.preventDefault()
+      seekForward()
+      break
+    case 'ArrowLeft':
+      event.preventDefault()
+      seekBackward()
+      break
+    // Volume
+    case 'ArrowUp':
+      event.preventDefault()
+      volumeUp()
+      break
+    case 'ArrowDown':
+      event.preventDefault()
+      volumeDown()
+      break
+    case 'M':
+    case 'm':
+      event.preventDefault()
+      toggleMute()
+      break
+  }
 }
 
-const onVideoError = () => {
-  isBuffering.value = false
-  isVideoError.value = true
+const handleVolumeMouseWheel = (event) => {
+  event.preventDefault()
+  if (event.deltaY > 0) {
+    // Scroll down
+    volumeDown()
+  } else {
+    // Scroll up
+    volumeUp()
+  }
 }
 
 onMounted(() => {
-  document.addEventListener('keydown', onKeyDown)
+  document.addEventListener('keydown', handleKeyDown)
 })
 
 onUnmounted(() => {
-  document.removeEventListener('keydown', onKeyDown)
+  document.removeEventListener('keydown', handleKeyDown)
 })
 </script>
 
 <template>
   <div
     id="playerContainer"
-    ref="overlayVideo"
+    ref="overlayVideoRef"
     class="has-full-size"
-    style="display: inline-flex"
-    @pointermove="handlePlayerPointerMove"
+    @pointermove="handlePlayerPointerEvent"
   >
     <video
       id="mediaPlayer"
-      ref="video"
+      ref="videoRef"
       crossorigin="anonymous"
-      @timeupdate="updateStatus"
-      @seeking="updateStatus"
+      @timeupdate="updatePlayerStatus"
+      @seeking="updatePlayerStatus"
       @pointerup="handlePlayerClick"
       @loadstart="isBuffering = true"
-      @loadeddata="onPlayerReady"
+      @loadeddata="handlePlayerLoaded"
       @waiting="isBuffering = true"
-      @playing="onVideoPlaying"
-      @error="onVideoError"
+      @playing="setBufferAndErrorState(false, false)"
+      @error="setBufferAndErrorState(false, true)"
       class="has-full-size"
       :src="resource?.isLive ? undefined : resource?.src"
       autoplay
@@ -472,12 +467,12 @@ onUnmounted(() => {
       id="mobileCenterControl"
       class="is-hidable has-flex-center has-horizontally-padded-huge"
     >
-      <button class="button-touch has-flex-center" @pointerup="onPlayButtonPointerUp">
+      <button class="button-touch has-flex-center" @pointerup="withHandlePointerEvent($event, togglePlay)">
         <span v-if="isPaused" class="ts-icon is-huge tablet+:is-heading is-play-icon" />
         <span v-else class="ts-icon is-huge tablet+:is-heading is-pause-icon" />
       </button>
     </div>
-    <div v-if="resource" class="ts-mask is-faded is-top is-hidable" @pointerup="onOverlayPointerUp">
+    <div v-if="resource" class="ts-mask is-faded is-top is-hidable" @pointerup="handlePlayerPointerEvent">
       <div class="ts-content" style="color: #fff">
         <div class="ts-header is-truncated">{{ resource.streamer }}</div>
         <span v-if="resource.isLive">
@@ -491,7 +486,7 @@ onUnmounted(() => {
         </span>
       </div>
     </div>
-    <div v-if="resource" class="ts-mask is-faded is-bottom is-hidable">
+    <div v-if="resource" class="ts-mask is-faded is-bottom is-hidable" @pointerup="handlePlayerPointerEvent">
       <div class="ts-content" style="color: #fff">
         <input
           v-if="!touchMode"
@@ -500,18 +495,17 @@ onUnmounted(() => {
           v-model="currentTime"
           :max="duration"
           step="any"
-          @input="onSeekDrag"
+          @input="debounceSeekDrag"
         />
         <div
           class="is-flex justify-between"
           :class="{ 'has-horizontally-padded': !touchMode }"
-          @pointerup="onOverlayPointerUp"
         >
           <div class="is-flex">
             <button
               v-if="!touchMode"
               class="button has-flex-center"
-              @pointerup="onPlayButtonPointerUp"
+              @pointerup="withHandlePointerEvent($event, togglePlay)"
             >
               <span v-if="isPaused" class="ts-icon tablet+:is-big is-play-icon" />
               <span v-else class="ts-icon tablet+:is-big is-pause-icon" />
@@ -521,9 +515,10 @@ onUnmounted(() => {
               v-model:volume="volume"
               :is-muted="isMuted"
               :convert-volume="convertVolume"
-              :reset-volume="resetVolume"
-              @mute-button-pointerup="onMuteButtonPointerUp"
-              @volume-mousewheel="onVolumeMouseWheel"
+              @reset-button-pointerup="withHandlePointerEvent($event, resetVolume)"
+              @mute-button-pointerup="withHandlePointerEvent($event, toggleMute)"
+              @volume-mousewheel="withHandlePointerEvent($event, handleVolumeMouseWheel)"
+              @pointerup="handlePlayerPointerEvent"
               @update:volume="setVolume"
             />
             <span>
@@ -537,21 +532,22 @@ onUnmounted(() => {
               v-model:volume="volume"
               :is-muted="isMuted"
               :convert-volume="convertVolume"
-              :reset-volume="resetVolume"
-              @mute-button-pointerup="onMuteButtonPointerUp"
-              @volume-mousewheel="onVolumeMouseWheel"
+              @reset-button-pointerup="withHandlePointerEvent($event, resetVolume)"
+              @mute-button-pointerup="withHandlePointerEvent($event, toggleMute)"
+              @volume-mousewheel="withHandlePointerEvent($event, handleVolumeMouseWheel)"
+              @pointerup="handlePlayerPointerEvent"
               @update:volume="setVolume"
             />
             <div v-if="qualityList.length > 1">
               <button
                 class="button has-flex-center"
                 data-dropdown="quality"
-                @pointerup="handlePlayerPointerMove"
+                @pointerup="handlePlayerPointerEvent"
               >
                 <span class="ts-icon tablet+:is-big is-images-icon" />
               </button>
               <div
-                ref="qualityDropdown"
+                ref="qualityDropdownRef"
                 class="ts-dropdown style-text"
                 data-name="quality"
                 data-position="top-end"
@@ -579,28 +575,28 @@ onUnmounted(() => {
               <button
                 class="button has-flex-center"
                 data-dropdown="speed"
-                @pointerup="handlePlayerPointerMove"
+                @pointerup="handlePlayerPointerEvent"
               >
                 <span class="ts-icon tablet+:is-big is-gauge-simple-high-icon" />
               </button>
               <div
-                ref="rateDropdown"
+                ref="rateDropdownRef"
                 class="ts-dropdown style-text"
                 data-name="speed"
                 data-position="top-end"
               >
                 <button
-                  v-for="rateItem in rateList"
+                  v-for="rateItem in playbackRateList"
                   :key="rateItem.value"
                   class="item"
-                  :class="{ 'is-selected': rateItem.value === rate }"
-                  @click="setRate(rateItem.value)"
+                  :class="{ 'is-selected': rateItem.value === playbackRate }"
+                  @click="setPlaybackRate(rateItem.value)"
                 >
                   {{ rateItem.text }}
                 </button>
               </div>
             </div>
-            <button class="button has-flex-center" @pointerup="onFullscreenButtonPointerUp">
+            <button class="button has-flex-center" @pointerup="withHandlePointerEvent($event, toggleFullscreen)">
               <span v-if="isFullscreen" class="ts-icon is-compress-icon" />
               <span v-else class="ts-icon tablet+:is-big is-expand-icon" />
             </button>
@@ -613,7 +609,7 @@ onUnmounted(() => {
           v-model="currentTime"
           :max="duration"
           step="any"
-          @input="onSeekDrag"
+          @input="debounceSeekDrag"
         />
       </div>
     </div>
@@ -621,6 +617,7 @@ onUnmounted(() => {
 </template>
 
 <style scoped>
+/* Auto Hide */
 .is-hidable {
   opacity: 0;
   transition-duration: 500ms;
@@ -638,16 +635,17 @@ onUnmounted(() => {
   opacity: 1;
 }
 
-.is-flex {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
+.auto-hidden,
+.auto-hidden * {
+  cursor: none;
 }
 
-.justify-between {
-  justify-content: space-between;
+/* Workaround tocas-ui's important */
+.auto-hidden .has-cursor-pointer {
+  cursor: none !important;
 }
 
+/* Elements */
 .button {
   width: 30px;
   height: 30px;
@@ -665,8 +663,8 @@ onUnmounted(() => {
   }
 }
 
-.style-text {
-  color: var(--ts-gray-900);
+#playerContainer {
+  display: inline-flex;
 }
 
 #playerContainer:not(:fullscreen) video {
@@ -674,11 +672,6 @@ onUnmounted(() => {
   max-height: 80vh;
   display: inline-flex;
   box-sizing: content-box;
-}
-
-.auto-hidden,
-.auto-hidden * {
-  cursor: none;
 }
 
 #mobileCenterControl {
@@ -693,8 +686,19 @@ onUnmounted(() => {
   text-shadow: #000 2px 2px 5px;
 }
 
-/* Workaround tocas-ui's important */
-.auto-hidden .has-cursor-pointer {
-  cursor: none !important;
+/* Util Styles */
+.is-flex {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
+
+.justify-between {
+  justify-content: space-between;
+}
+
+.style-text {
+  color: var(--ts-gray-900);
+}
+
 </style>

--- a/src/components/centerBlock/OverlayPlayer.vue
+++ b/src/components/centerBlock/OverlayPlayer.vue
@@ -60,7 +60,9 @@ const updatePlayerStatus = () => {
   duration.value = videoRef.value?.duration
   isPaused.value = videoRef.value?.paused
   isMuted.value = videoRef.value?.muted
-  volume.value = videoRef.value?.muted ? 0 : reverseVolume(videoAmplifier.value?.getAmpLevel() * 100)
+  volume.value = videoRef.value?.muted
+    ? 0
+    : reverseVolume(videoAmplifier.value?.getAmpLevel() * 100)
   isFullscreen.value = document.fullscreenElement !== null
   playbackRate.value = videoRef.value?.playbackRate
 }
@@ -467,12 +469,19 @@ onUnmounted(() => {
       id="mobileCenterControl"
       class="is-hidable has-flex-center has-horizontally-padded-huge"
     >
-      <button class="button-touch has-flex-center" @pointerup="withHandlePointerEvent($event, togglePlay)">
+      <button
+        class="button-touch has-flex-center"
+        @pointerup="withHandlePointerEvent($event, togglePlay)"
+      >
         <span v-if="isPaused" class="ts-icon is-huge tablet+:is-heading is-play-icon" />
         <span v-else class="ts-icon is-huge tablet+:is-heading is-pause-icon" />
       </button>
     </div>
-    <div v-if="resource" class="ts-mask is-faded is-top is-hidable" @pointerup="handlePlayerPointerEvent">
+    <div
+      v-if="resource"
+      class="ts-mask is-faded is-top is-hidable"
+      @pointerup="handlePlayerPointerEvent"
+    >
       <div class="ts-content" style="color: #fff">
         <div class="ts-header is-truncated">{{ resource.streamer }}</div>
         <span v-if="resource.isLive">
@@ -486,7 +495,11 @@ onUnmounted(() => {
         </span>
       </div>
     </div>
-    <div v-if="resource" class="ts-mask is-faded is-bottom is-hidable" @pointerup="handlePlayerPointerEvent">
+    <div
+      v-if="resource"
+      class="ts-mask is-faded is-bottom is-hidable"
+      @pointerup="handlePlayerPointerEvent"
+    >
       <div class="ts-content" style="color: #fff">
         <input
           v-if="!touchMode"
@@ -497,10 +510,7 @@ onUnmounted(() => {
           step="any"
           @input="debounceSeekDrag"
         />
-        <div
-          class="is-flex justify-between"
-          :class="{ 'has-horizontally-padded': !touchMode }"
-        >
+        <div class="is-flex justify-between" :class="{ 'has-horizontally-padded': !touchMode }">
           <div class="is-flex">
             <button
               v-if="!touchMode"
@@ -596,7 +606,10 @@ onUnmounted(() => {
                 </button>
               </div>
             </div>
-            <button class="button has-flex-center" @pointerup="withHandlePointerEvent($event, toggleFullscreen)">
+            <button
+              class="button has-flex-center"
+              @pointerup="withHandlePointerEvent($event, toggleFullscreen)"
+            >
               <span v-if="isFullscreen" class="ts-icon is-compress-icon" />
               <span v-else class="ts-icon tablet+:is-big is-expand-icon" />
             </button>
@@ -700,5 +713,4 @@ onUnmounted(() => {
 .style-text {
   color: var(--ts-gray-900);
 }
-
 </style>

--- a/src/components/centerBlock/OverlayPlayer/VolumeControl.vue
+++ b/src/components/centerBlock/OverlayPlayer/VolumeControl.vue
@@ -11,14 +11,15 @@ defineProps({
   convertVolume: {
     type: Function,
     required: true
-  },
-  resetVolume: {
-    type: Function,
-    required: true
   }
 })
 
-defineEmits(['mute-button-pointerup', 'volume-mousewheel', 'update:volume'])
+defineEmits([
+  'mute-button-pointerup',
+  'volume-mousewheel',
+  'reset-button-pointerup',
+  'update:volume'
+])
 </script>
 
 <template>
@@ -50,9 +51,13 @@ defineEmits(['mute-button-pointerup', 'volume-mousewheel', 'update:volume'])
     <datalist id="volumeMarkers">
       <option value="100"></option>
     </datalist>
-    <span class="mobile:has-hidden has-cursor-pointer" title="按一下重置音量" @click="resetVolume"
-      >{{ Math.round(convertVolume(volume)) }}%</span
+    <span
+      class="mobile:has-hidden has-cursor-pointer"
+      title="按一下重置音量"
+      @pointerup="$emit('reset-button-pointerup', $event)"
     >
+      {{ Math.round(convertVolume(volume)) }}%
+    </span>
   </div>
 </template>
 

--- a/src/components/centerBlock/OverlayPlayer/VolumeControl.vue
+++ b/src/components/centerBlock/OverlayPlayer/VolumeControl.vue
@@ -1,0 +1,76 @@
+<script setup>
+defineProps({
+  volume: {
+    type: Number,
+    required: true
+  },
+  isMuted: {
+    type: Boolean,
+    required: true
+  },
+  convertVolume: {
+    type: Function,
+    required: true
+  },
+  resetVolume: {
+    type: Function,
+    required: true
+  }
+})
+
+defineEmits(['mute-button-pointerup', 'volume-mousewheel', 'update:volume'])
+</script>
+
+<template>
+  <div class="is-flex">
+    <button
+      class="button has-flex-center"
+      @pointerup="$emit('mute-button-pointerup', $event)"
+      @wheel="$emit('volume-mousewheel', $event)"
+    >
+      <span v-if="isMuted" class="ts-icon tablet+:is-big is-volume-xmark-icon" />
+      <span v-else-if="volume === 0" class="ts-icon tablet+:is-big is-volume-off-icon" />
+      <span v-else-if="volume <= 50" class="ts-icon tablet+:is-big is-volume-low-icon" />
+      <span
+        v-else
+        class="ts-icon tablet+:is-big is-volume-high-icon"
+        :style="{ color: volume > 100 ? 'var(--ts-negative-400)' : 'var(--ts-white)' }"
+      />
+    </button>
+    <input
+      type="range"
+      class="mobile:has-hidden has-cursor-pointer player-slider"
+      :value="volume"
+      :max="150"
+      step="any"
+      list="volumeMarkers"
+      @input="$emit('update:volume', $event.target.value)"
+      @wheel="$emit('volume-mousewheel', $event)"
+    />
+    <datalist id="volumeMarkers">
+      <option value="100"></option>
+    </datalist>
+    <span class="mobile:has-hidden has-cursor-pointer" title="按一下重置音量" @click="resetVolume"
+      >{{ Math.round(convertVolume(volume)) }}%</span
+    >
+  </div>
+</template>
+
+<style scoped>
+.button {
+  width: 30px;
+  height: 30px;
+}
+
+.is-flex {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Workaround tocas-ui's important */
+.auto-hidden .has-cursor-pointer,
+.auto-hidden button {
+  cursor: none !important;
+}
+</style>


### PR DESCRIPTION
## Changes

- 重寫播放器點擊事件  
> # 滑鼠
>   單擊 => 切換暫停 (無延遲)
>   雙擊 => 切換全螢幕 + 切換暫停 (取消單擊效果)
>   在播放器上移動鼠標 => 顯示UI並重設自動隱藏時間
>   
>   # 觸控
>   ## UI隱藏時
>   單擊 => 顯示UI (無延遲)
>   雙擊 => 切換全螢幕 + 隱藏UI (取消單擊效果)
>   ## UI顯示時
>   單擊 => 隱藏UI (延遲300ms以偵測是否雙擊)
>   雙擊左1/3螢幕 => 倒轉
>   雙擊右1/3螢幕 => 快轉
>   雙擊中央1/3 => 切換暫停  
- 把變數和方法全部重新命名一遍
- 把相關功能放在一起並分類

## Changes from #18

- ~~取消非左鍵的按鈕事件~~
- 在平板寬度以上放大播放器按鈕
- ~~取消觸控裝置上的按一下播放暫停，恢復點兩下觸發兩次 onClick~~
- 觸控裝置上的控制按鈕並調整介面元件位置
- 修正載入中無法暫停

